### PR TITLE
Indicate specific urwid version required for hachoir-urwid.

### DIFF
--- a/doc/urwid.rst
+++ b/doc/urwid.rst
@@ -14,6 +14,9 @@ reprensentation.
 **hachoir-urwid** is the most user friendly interface based on Hachoir to
 explore a binary file.
 
+Before use, make sure to install the required dependencies with ``pip install
+hachoir[urwid]``.
+
 .. image:: images/urwid.png
    :alt: hachoir-urwid screenshot (MP3 audio file)
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,11 @@ def main():
         "packages": find_packages(),
         "package_data": {"hachoir.wx.resource": ['hachoir_wx.xrc']},
         "entry_points": ENTRY_POINTS,
+        "extras_require": {
+            "urwid": [
+                "urwid==1.3.1"
+            ]
+        },
         "zip_safe": True,
     }
     setup(**install_options)


### PR DESCRIPTION
Fixes #35.

Can be tested locally with `pip install . .[urwid]`.