### PR TITLE
Fix for calling Dict.values property from MultipleMetadata.iterGroups

### DIFF
--- a/hachoir/metadata/metadata.py
+++ b/hachoir/metadata/metadata.py
@@ -243,7 +243,7 @@ class MultipleMetadata(RootMetadata):
         return self.__groups[key]
 
     def iterGroups(self):
-        return iter(self.__groups.values())
+        return iter(self.__groups.values)
 
     def __bool__(self):
         if RootMetadata.__bool__(self):

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -71,6 +71,23 @@ class TestMetadata(unittest.TestCase):
 
         self.assertEqual(required_meta, meta)
 
+    def test_plaintext_output(self):
+        expected_plaintext = [['Video stream:',
+                               '- Language: French',
+                               '- Image width: 384 pixels',
+                               '- Image height: 288 pixels',
+                               '- Compression: V_MPEG4/ISO/AVC'],
+                              ['Audio stream:',
+                               '- Title: travail = aliénation (extrait)',
+                               '- Language: French',
+                               '- Channel: mono',
+                               '- Sample rate: 44.1 kHz',
+                               '- Compression: A_VORBIS']]
+        with createParser(os.path.join(DATADIR, "flashmob.mkv")) as parser:
+            extractor = extractMetadata(parser)
+        groups = [g.exportPlaintext() for g in extractor.iterGroups()]
+        self.assertEqual(groups, expected_plaintext)
+
     def check_attr(self, metadata, name, value):
         if self.verbose:
             sys.stdout.write("  - Check metadata %s=%s: " %


### PR DESCRIPTION
Since Dict.values is a property, then MultipleMetadata.iterGroups should return it properly. Now when called it crashes with:
```
    /hachoir/metadata/metadata.py line 246 in iterGroups
      return iter(self.__groups.values())
   TypeError: 'list' object is not callable
```