### PR TITLE
Fix for ASF/WMV duration.

### DIFF
--- a/hachoir/core/tools.py
+++ b/hachoir/core/tools.py
@@ -536,6 +536,23 @@ def durationWin64(value):
     return timedelta(microseconds=value / 10)
 
 
+def durationMillisWin64(value):
+    """
+    Convert Windows 64-bit duration to string. The timestamp format is
+    a 64-bit number: number of milliseconds. See also timestampMilliWin64().
+
+    >>> str(durationMillisWin64(107258))
+    '0:01:47.258000'
+    >>> str(durationMillisWin64(214628))
+    '0:03:34.628000'
+    """
+    if not isinstance(value, (float, int)):
+        raise TypeError("an integer or float is required")
+    if value < 0:
+        raise ValueError("value have to be a positive or nul integer")
+    return timedelta(microseconds=value * 1000)
+
+
 # Start of 64-bit Windows timestamp: 1st January 1600 at 00:00
 WIN64_TIMESTAMP_T0 = datetime(1601, 1, 1, 0, 0, 0)
 

--- a/hachoir/field/__init__.py
+++ b/hachoir/field/__init__.py
@@ -36,7 +36,7 @@ from hachoir.field.vector import GenericVector, UserVector  # noqa
 from hachoir.field.float import Float32, Float64, Float80  # noqa
 from hachoir.field.timestamp import (GenericTimestamp,  # noqa
     TimestampUnix32, TimestampUnix64, TimestampMac32, TimestampUUID60,
-    TimestampWin64,
+    TimestampWin64, TimedeltaMillisWin64,
     DateTimeMSDOS32, TimeDateMSDOS32, TimedeltaWin64)
 
 # Special Field classes
@@ -55,6 +55,7 @@ available_types = (Bit, Bits, RawBits,
                    PaddingBits, PaddingBytes,
                    NullBits, NullBytes,
                    TimestampUnix32, TimestampMac32, TimestampWin64,
+                   TimedeltaMillisWin64,
                    DateTimeMSDOS32, TimeDateMSDOS32,
                    #                   GenericInteger, GenericString,
                    )

--- a/hachoir/field/timestamp.py
+++ b/hachoir/field/timestamp.py
@@ -1,6 +1,6 @@
 from hachoir.core.tools import (humanDatetime, humanDuration,
                                 timestampUNIX, timestampMac32, timestampUUID60,
-                                timestampWin64, durationWin64)
+                                timestampWin64, durationWin64, durationMillisWin64)
 from hachoir.field import Bits, FieldSet
 from datetime import datetime
 
@@ -93,3 +93,16 @@ class TimedeltaWin64(GenericTimestamp):
     def createValue(self):
         value = Bits.createValue(self)
         return durationWin64(value)
+
+
+class TimedeltaMillisWin64(GenericTimestamp):
+
+    def __init__(self, parent, name, description=None):
+        GenericTimestamp.__init__(self, parent, name, 64, description)
+
+    def createDisplay(self):
+        return humanDuration(self.value)
+
+    def createValue(self):
+        value = Bits.createValue(self)
+        return durationMillisWin64(value)

--- a/hachoir/metadata/video.py
+++ b/hachoir/metadata/video.py
@@ -384,7 +384,7 @@ class AsfMetadata(MultipleMetadata):
     @fault_tolerant
     def useFileProp(self, prop, is_vbr):
         self.creation_date = prop["creation_date"].value
-        self.duration = prop["play_duration"].value
+        self.duration = prop["play_duration"].value - prop["preroll"].value
         if prop["seekable"].value:
             self.comment = "Is seekable"
         value = prop["max_bitrate"].value

--- a/hachoir/parser/video/asf.py
+++ b/hachoir/parser/video/asf.py
@@ -14,6 +14,7 @@ from hachoir.parser import Parser
 from hachoir.field import (FieldSet, ParserError,
                            UInt16, UInt32, UInt64,
                            TimestampWin64, TimedeltaWin64,
+                           TimedeltaMillisWin64,
                            String, PascalString16, Enum,
                            Bit, Bits, PaddingBits,
                            PaddingBytes, NullBytes, RawBytes)
@@ -93,7 +94,7 @@ class FileProperty(FieldSet):
         yield UInt64(self, "pckt_count")
         yield TimedeltaWin64(self, "play_duration")
         yield TimedeltaWin64(self, "send_duration")
-        yield UInt64(self, "preroll")
+        yield TimedeltaMillisWin64(self, "preroll")
         yield Bit(self, "broadcast", "Is broadcast?")
         yield Bit(self, "seekable", "Seekable stream?")
         yield PaddingBits(self, "reserved[]", 30)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -297,7 +297,7 @@ class TestMetadata(unittest.TestCase):
         meta = self.extract("matrix_ping_pong.wmv")
         self.check_attr(meta, "title", "欽ちゃん＆香取慎吾の全日本仮装大賞")
         self.check_attr(meta, "duration", timedelta(
-            minutes=1, seconds=47, milliseconds=258))
+            minutes=1, seconds=43, milliseconds=900))
         self.check_attr(meta, "creation_date", datetime(
             2003, 6, 16, 7, 57, 23, 235000))
         self.check_attr(meta, "audio[1]/sample_rate", 8000)


### PR DESCRIPTION
Parsed duration for ASF/WMV files is usually wrong. As an example, the parsed metadata for the test demo file "matrix_ping_pong.wmv" says it lasts 1:47.258, but players show it's length as 1:43 or 1:44 (depending which way they round).

This is because the "play_duration" field includes the preroll/buffering time. Thus, to get the actual duration of the video, we must subtract the "preroll" field from the "play_duration" field.

Additional complication: While the "play_duration" and "send_duration" fields are 64-bit integers 100ns counts, "preroll" is a 64-bit integer *millisecond* count. So new code is needed to deal with that.