### PR TITLE
Add possibility to get metadata within Python

### DIFF
--- a/hachoir/metadata/main.py
+++ b/hachoir/metadata/main.py
@@ -180,7 +180,7 @@ def getMetadata(args, display=False):
         --raw       Raw output - default is False
         --quality   Information quality (0.0=fastest, 1.0=best, and default is 0.5)
         --maxlen    Maximum string length in characters, 0 means unlimited
-                        (default is defined in ...\hachoir\metadata\config.py (usually 300))
+                        (default is defined in ...\\hachoir\\metadata\\config.py (usually 300))
 
     Raises:
         FileNotFoundError: If the args list do not contain any file path.


### PR DESCRIPTION
I was looking for a tool to get video metadata in Python for a project I work on.
I found this thread: https://stackoverflow.com/q/51342429/5806912

So I took a look at the source, and I found an easy way to allow users to retrieve metadata within Python.

Here a snippet of how to call it with the proposed modification (might be useful for the documentation):

```python
from hachoir.metadata.main import main
try:
    d = main(['--get-dict', 'PATH_TO_VIDEO.mkv'])
except SystemExit:
    pass
```
