### PR TITLE
Synchronize maximum copy bits count with the fieldset limit

### DIFF
--- a/hachoir/stream/output.py
+++ b/hachoir/stream/output.py
@@ -2,6 +2,7 @@ from io import StringIO
 from hachoir.core.endian import BIG_ENDIAN, LITTLE_ENDIAN
 from hachoir.core.bits import long2raw
 from hachoir.stream import StreamError
+from hachoir.core import config
 from errno import EBADF
 
 MAX_READ_NBYTES = 2 ** 16
@@ -116,7 +117,7 @@ class OutputStream(object):
         else:
             # Arbitrary limit (because we should use a buffer, like copyBytesFrom(),
             # but with endianess problem
-            assert nb_bits <= 128
+            assert nb_bits <= config.max_bit_length
             data = input.readBits(address, nb_bits, endian)
             self.writeBits(nb_bits, data, endian)
 


### PR DESCRIPTION
Synchronize maximum copy bits count with the fieldset limit the config.
This assertion prevented me from rewriting sets of 256 raw bits due to the 128-bit limit.

The size limit when yielding an instance of RawBits is 256 bits, so imho it makes sense to synchronize with that value.