### PR TITLE
Hachoir.editor: Allow writing unaligned bitstreams

### DIFF
--- a/hachoir/editor/field.py
+++ b/hachoir/editor/field.py
@@ -63,7 +63,7 @@ class FakeField(object):
         addr = self._parent._getFieldInputAddress(self._name)
         input = self._parent.input
         stream = input.stream
-        if size % 8:
+        if size % 8 or addr % 8:
             output.copyBitsFrom(stream, addr, size, input.endian)
         else:
             output.copyBytesFrom(stream, addr, size // 8)

--- a/hachoir/stream/output.py
+++ b/hachoir/stream/output.py
@@ -112,7 +112,7 @@ class OutputStream(object):
         self.writeBytes(raw)
 
     def copyBitsFrom(self, input, address, nb_bits, endian):
-        if (nb_bits % 8) == 0 and (self._bit_pos % 8) == 0:
+        if (nb_bits % 8) == 0 and (address % 8) == 0 and (self._bit_pos % 8) == 0:
             self.copyBytesFrom(input, address, nb_bits // 8)
         else:
             # Arbitrary limit (because we should use a buffer, like copyBytesFrom(),

--- a/hachoir/stream/output.py
+++ b/hachoir/stream/output.py
@@ -112,14 +112,11 @@ class OutputStream(object):
         self.writeBytes(raw)
 
     def copyBitsFrom(self, input, address, nb_bits, endian):
-        if (nb_bits % 8) == 0:
-            self.copyBytesFrom(input, address, nb_bits // 8)
-        else:
-            # Arbitrary limit (because we should use a buffer, like copyBytesFrom(),
-            # but with endianess problem
-            assert nb_bits <= config.max_bit_length
-            data = input.readBits(address, nb_bits, endian)
-            self.writeBits(nb_bits, data, endian)
+        # Arbitrary limit (because we should use a buffer, like copyBytesFrom(),
+        # but with endianess problem
+        assert nb_bits <= config.max_bit_length
+        data = input.readBits(address, nb_bits, endian)
+        self.writeBits(nb_bits, data, endian)
 
     def copyBytesFrom(self, input, address, nb_bytes):
         if (address % 8):

--- a/hachoir/stream/output.py
+++ b/hachoir/stream/output.py
@@ -112,11 +112,14 @@ class OutputStream(object):
         self.writeBytes(raw)
 
     def copyBitsFrom(self, input, address, nb_bits, endian):
-        # Arbitrary limit (because we should use a buffer, like copyBytesFrom(),
-        # but with endianess problem
-        assert nb_bits <= config.max_bit_length
-        data = input.readBits(address, nb_bits, endian)
-        self.writeBits(nb_bits, data, endian)
+        if (nb_bits % 8) == 0 and (self._bit_pos % 8) == 0:
+            self.copyBytesFrom(input, address, nb_bits // 8)
+        else:
+            # Arbitrary limit (because we should use a buffer, like copyBytesFrom(),
+            # but with endianess problem
+            assert nb_bits <= config.max_bit_length
+            data = input.readBits(address, nb_bits, endian)
+            self.writeBits(nb_bits, data, endian)
 
     def copyBytesFrom(self, input, address, nb_bytes):
         if (address % 8):

--- a/hachoir/stream/output.py
+++ b/hachoir/stream/output.py
@@ -2,6 +2,7 @@ from io import StringIO
 from hachoir.core.endian import BIG_ENDIAN, LITTLE_ENDIAN
 from hachoir.core.bits import long2raw
 from hachoir.stream import StreamError
+from hachoir.core import config
 from errno import EBADF
 
 MAX_READ_NBYTES = 2 ** 16
@@ -116,7 +117,7 @@ class OutputStream(object):
         else:
             # Arbitrary limit (because we should use a buffer, like copyBytesFrom(),
             # but with endianess problem
-            assert nb_bits <= 128
+            assert nb_bits <= config.max_bit_length
             data = input.readBits(address, nb_bits, endian)
             self.writeBits(nb_bits, data, endian)
 

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,0 +1,42 @@
+import unittest
+from io import BytesIO
+from hachoir.core.endian import BIG_ENDIAN, LITTLE_ENDIAN
+from hachoir.editor import createEditor
+from hachoir.field import FieldSet, Parser, Bits
+from hachoir.stream import StringInputStream, OutputStream
+from hachoir.test import setup_tests
+
+class TestEditor(unittest.TestCase):
+    def test_bit_alignment(self):
+        data = bytes([255, 255, 255, 254])
+        stream = StringInputStream(data)
+        parser = TestParser(stream)
+        editor = createEditor(parser)
+
+        # Cause a change in a non-byte-aligned field
+        editor['flags[2]'].value -= 1
+
+        # Generate output and verify operation
+        output_io = BytesIO()
+        output_stream = OutputStream(output_io)
+
+        editor.writeInto(output_stream)
+        output_bits = "{0:b}".format(int.from_bytes(output_io.getvalue(), 'big'))
+
+        # X is the modified bit
+        #                              .....,,,,,,,,,,,,,,,,..X,,,,,,,,
+        self.assertEqual(output_bits, "11111111111111111111111011111110")
+
+class TestParser(Parser):
+    endian = BIG_ENDIAN
+
+    def createFields(self):
+        yield Bits(self, 'flags[]', 5)
+        yield Bits(self, 'flags[]', 16)
+        yield Bits(self, 'flags[]', 3)
+        yield Bits(self, 'flags[]', 8)
+
+
+if __name__ == "__main__":
+    setup_tests()
+    unittest.main()

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,10 +1,11 @@
 import unittest
 from io import BytesIO
-from hachoir.core.endian import BIG_ENDIAN, LITTLE_ENDIAN
+from hachoir.core.endian import BIG_ENDIAN
 from hachoir.editor import createEditor
-from hachoir.field import FieldSet, Parser, Bits
+from hachoir.field import Parser, Bits
 from hachoir.stream import StringInputStream, OutputStream
 from hachoir.test import setup_tests
+
 
 class TestEditor(unittest.TestCase):
     def test_bit_alignment(self):
@@ -26,6 +27,7 @@ class TestEditor(unittest.TestCase):
         # X is the modified bit
         #                              .....,,,,,,,,,,,,,,,,..X,,,,,,,,
         self.assertEqual(output_bits, "11111111111111111111111011111110")
+
 
 class TestParser(Parser):
     endian = BIG_ENDIAN


### PR DESCRIPTION
The current implementation sometimes attempts to write a set of bytes (which is more efficient) when the input size is a multiple of 8. However, when the output stream is not aligned to bytes (e.g. because some bits have been written), this causes a crash in `hachoir/editor/output.py`.

This PR does the following:
1. Detect when the target address is not byte-aligned, and request bits to be written if found true.
2. Disable the byte-writing optimization altogether.

The last item could be considered a work-around (what I'm trying to do works with this PR). However, when updating checks all along the regular implementation path (which usually involves checking whether `output._bit_pos % 8 != 0`, otherwise we eventually end up in `OutputStream.writeBytes` on line 143, which raises a NotImplementedError) caused `editor.EditableFieldSet` to request writing more than 256 bits (which fails the assertion in `output.py` on line 117). I tried working around that by writing 256 bits at a time, but that slowed down the parser to a crawl.

In my opinion, this PR provides a balance by disabling an optimization, while still allowing efficiently copying of both bit and byte-aligned fields. All the while avoiding to implement bit-aligned writing of bytes.

However, you may not want to disable that optimization for your use-cases. In that case, I would recommend only keeping the bugfix in `field.py`.