### PR TITLE
Added passing byte stream to FileInputStream

### DIFF
--- a/hachoir/parser/guess.py
+++ b/hachoir/parser/guess.py
@@ -127,8 +127,8 @@ def createParser(filename, real_filename=None, tags=None):
     Create a parser from a file or returns None on error.
 
     Options:
-    - file (unicode|bytes|io.IOBase): Input file name, byte array
-        or a byte io.IOBase stream  ;
+    - file (unicode|io.IOBase): Input file name or
+        a byte io.IOBase stream  ;
     - real_filename (str|unicode): Real file name.
     """
     if not tags:

--- a/hachoir/parser/guess.py
+++ b/hachoir/parser/guess.py
@@ -127,9 +127,9 @@ def createParser(filename, real_filename=None, tags=None):
     Create a parser from a file or returns None on error.
 
     Options:
-    - file (unicode|io.IOBase): Input file name or
+    - file (str|io.IOBase): Input file name or
         a byte io.IOBase stream  ;
-    - real_filename (str|unicode): Real file name.
+    - real_filename (str): Real file name.
     """
     if not tags:
         tags = []

--- a/hachoir/parser/guess.py
+++ b/hachoir/parser/guess.py
@@ -127,7 +127,8 @@ def createParser(filename, real_filename=None, tags=None):
     Create a parser from a file or returns None on error.
 
     Options:
-    - filename (unicode): Input file name ;
+    - file (unicode|bytes|io.IOBase): Input file name, byte array
+        or a byte io.IOBase stream  ;
     - real_filename (str|unicode): Real file name.
     """
     if not tags:

--- a/hachoir/stream/input_helper.py
+++ b/hachoir/stream/input_helper.py
@@ -5,7 +5,8 @@ import io
 
 def FileInputStream(filename, real_filename=None, **args):
     """
-    Create an input stream of a file. filename must be unicode.
+    Create an input stream of a file. filename must be unicode or a file
+    object.
 
     real_filename is an optional argument used to specify the real filename,
     its type can be 'str' or 'unicode'. Use real_filename when you are
@@ -16,18 +17,15 @@ def FileInputStream(filename, real_filename=None, **args):
         real_filename = filename
     try:
         if isinstance(filename, str):
-            inputio = open(filename, 'rb')
-        elif isinstance(filename, bytes):
-            inputio = io.BytesIO(filename)
+            inputio = open(real_filename, 'rb')
         else:
             inputio = filename
     except IOError as err:
         errmsg = str(err)
         raise InputStreamError(
             "Unable to open file %s: %s" % (filename, errmsg))
-    filename = (getattr(filename, 'name', '')
-                if hasattr(filename, 'read')
-                else str(real_filename))
+    filename = (filename if isinstance(filename, str)
+                else getattr(filename, 'name', ''))
     source = "file:" + filename
     offset = args.pop("offset", 0)
     size = args.pop("size", None)

--- a/hachoir/stream/input_helper.py
+++ b/hachoir/stream/input_helper.py
@@ -1,6 +1,5 @@
 from hachoir.core.i18n import guessBytesCharset
 from hachoir.stream import InputIOStream, InputSubStream, InputStreamError
-import io
 
 
 def FileInputStream(filename, real_filename=None, **args):

--- a/hachoir/stream/input_helper.py
+++ b/hachoir/stream/input_helper.py
@@ -13,18 +13,18 @@ def FileInputStream(filename, real_filename=None, **args):
     use unicode(name, 'replace') or unicode(name, 'ignore')).
     """
     if not real_filename:
-        real_filename = filename
+        real_filename = (filename if isinstance(filename, str)
+                         else getattr(filename, 'name', ''))
     try:
         if isinstance(filename, str):
             inputio = open(real_filename, 'rb')
         else:
             inputio = filename
+            filename = getattr(filename, 'name', '')
     except IOError as err:
         errmsg = str(err)
         raise InputStreamError(
             "Unable to open file %s: %s" % (filename, errmsg))
-    filename = (filename if isinstance(filename, str)
-                else getattr(filename, 'name', ''))
     source = "file:" + filename
     offset = args.pop("offset", 0)
     size = args.pop("size", None)

--- a/hachoir/stream/input_helper.py
+++ b/hachoir/stream/input_helper.py
@@ -1,5 +1,6 @@
 from hachoir.core.i18n import guessBytesCharset
 from hachoir.stream import InputIOStream, InputSubStream, InputStreamError
+import io
 
 
 def FileInputStream(filename, real_filename=None, **args):
@@ -11,15 +12,22 @@ def FileInputStream(filename, real_filename=None, **args):
     not able to convert filename to real unicode string (ie. you have to
     use unicode(name, 'replace') or unicode(name, 'ignore')).
     """
-    assert isinstance(filename, str)
     if not real_filename:
         real_filename = filename
     try:
-        inputio = open(real_filename, 'rb')
+        if isinstance(filename, str):
+            inputio = open(filename, 'rb')
+        elif isinstance(filename, bytes):
+            inputio = io.BytesIO(filename)
+        else:
+            inputio = filename
     except IOError as err:
         errmsg = str(err)
         raise InputStreamError(
             "Unable to open file %s: %s" % (filename, errmsg))
+    filename = (getattr(filename, 'name', '')
+                    if hasattr(filename, 'read')
+                    else str(real_filename))
     source = "file:" + filename
     offset = args.pop("offset", 0)
     size = args.pop("size", None)

--- a/hachoir/stream/input_helper.py
+++ b/hachoir/stream/input_helper.py
@@ -26,8 +26,8 @@ def FileInputStream(filename, real_filename=None, **args):
         raise InputStreamError(
             "Unable to open file %s: %s" % (filename, errmsg))
     filename = (getattr(filename, 'name', '')
-                    if hasattr(filename, 'read')
-                    else str(real_filename))
+                if hasattr(filename, 'read')
+                else str(real_filename))
     source = "file:" + filename
     offset = args.pop("offset", 0)
     size = args.pop("size", None)


### PR DESCRIPTION
[_Telethon_](https://github.com/LonamiWebs/Telethon) uses _hachoir_ to extract metadata from audio and video files. But I read that it only does so for files on the local disk since _hachoir_ doesn't create parsers from byte arrays and byte streams. So I added the ability to create streams from the passed filename, so the parsers could be created from byte array and streams.
Two things:
- The context manager closes the file when it exits, so it also closes BytesIO files. But I don't know if that's the expected outcome, or the file's expected to be closed even if it's a BytesIO object.
- I only tried passing the parser to `extractMetadata`, and that worked without a hitch. But I don't know if that'd be the case for other functions too. But since the stream gets constructed correctly, I don't see why there would be a problem. And all the tests succeed, so that must be good.

I'd love to hear your thoughts on this.