### PR TITLE
Update the urwid link

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -7,7 +7,7 @@ To install Hachoir, type::
     python3 -m pip install -U hachoir
 
 To use hachoir-urwid, you will also need to install `urwid library
-<http://excess.org/urwid/>`_::
+<http://urwid.org/>`_::
 
     python3 -m pip install -U urwid
 


### PR DESCRIPTION
The urwid website moved without leaving a forwarding address, so the link was broken.
Fix it.