### PR TITLE
fix bytes concat on repair

### DIFF
--- a/hachoir/field/string_field.py
+++ b/hachoir/field/string_field.py
@@ -244,7 +244,7 @@ class GenericString(Bytes):
                 and err.end == len(text) \
                 and self._charset == "UTF-16-LE":
             try:
-                text = str(text + "\0", self._charset, "strict")
+                text = str(text + b"\0", self._charset, "strict")
                 self.warning(
                     "Fix truncated %s string: add missing nul byte" % self._charset)
                 return text


### PR DESCRIPTION
Original code would yield a:
"[err!]: Unable to create value: can't concat str to bytes"
which would subsequently lead to a:
"[err!]: Error during metadata extraction: 'NoneType' object has no attribute 'strip'" and rightfully so.

This will resolve that error 😁