### PR TITLE
Improve OpenType/TrueType support

### DIFF
--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -16,6 +16,7 @@ from hachoir.parser import Parser
 from hachoir.field import (
     FieldSet,
     ParserError,
+    UInt8,
     UInt16,
     UInt32,
     Int16,
@@ -293,6 +294,51 @@ def parseHhea(self):
     yield Int16(self, "numberOfHMetrics", "Number of horizontal metrics")
 
 
+def parseOS2(self):
+    yield UInt16(self, "version", "Table version")
+    yield Int16(self, "xAvgCharWidth")
+    yield UInt16(self, "usWeightClass")
+    yield UInt16(self, "usWidthClass")
+    yield UInt16(self, "fsType")
+    yield Int16(self, "ySubscriptXSize")
+    yield Int16(self, "ySubscriptYSize")
+    yield Int16(self, "ySubscriptXOffset")
+    yield Int16(self, "ySubscriptYOffset")
+    yield Int16(self, "ySuperscriptXSize")
+    yield Int16(self, "ySuperscriptYSize")
+    yield Int16(self, "ySuperscriptXOffset")
+    yield Int16(self, "ySuperscriptYOffset")
+    yield Int16(self, "yStrikeoutSize")
+    yield Int16(self, "yStrikeoutPosition")
+    yield Int16(self, "sFamilyClass")
+    yield GenericVector(self, "panose", 10, UInt8)
+    yield UInt32(self, "ulUnicodeRange1")
+    yield UInt32(self, "ulUnicodeRange2")
+    yield UInt32(self, "ulUnicodeRange3")
+    yield UInt32(self, "ulUnicodeRange4")
+    yield Tag(self, "achVendID", "Vendor ID")
+    yield UInt16(self, "fsSelection")
+    yield UInt16(self, "usFirstCharIndex")
+    yield UInt16(self, "usLastCharIndex")
+    yield Int16(self, "sTypoAscender")
+    yield Int16(self, "sTypoDescender")
+    yield Int16(self, "sTypoLineGap")
+    yield UInt16(self, "usWinAscent")
+    yield UInt16(self, "usWinDescent")
+    if self["version"].value >= 1:
+        yield UInt32(self, "ulCodePageRange1")
+        yield UInt32(self, "ulCodePageRange2")
+    if self["version"].value >= 2:
+        yield Int16(self, "sxHeight")
+        yield Int16(self, "sCapHeight")
+        yield UInt16(self, "usDefaultChar")
+        yield UInt16(self, "usBreakChar")
+        yield UInt16(self, "usMaxContext")
+    if self["version"].value >= 5:
+        yield UInt16(self, "usLowerOpticalPointSize")
+        yield UInt16(self, "usUpperOpticalPointSize")
+
+
 parseScriptList = parseFeatureList = parseLookupList = lambda x: None
 
 
@@ -336,6 +382,7 @@ class Table(FieldSet):
         "maxp": ("maxp", "Maximum Profile", parseMaxp),
         "hhea": ("hhea", "Horizontal Header", parseHhea),
         "GSUB": ("GSUB", "Glyph Substitutions", parseGSUB),
+        "OS/2": ("OS/2", "OS/2 and Windows Metrics", parseOS2),
     }
 
     def __init__(self, parent, name, table, **kw):

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -251,10 +251,15 @@ class TrueTypeFontFile(Parser):
     }
 
     def validate(self):
-        if self["maj_ver"].value != 1:
-            return "Invalid major version (%u)" % self["maj_ver"].value
-        if self["min_ver"].value != 0:
-            return "Invalid minor version (%u)" % self["min_ver"].value
+        if self["maj_ver"].value == 1 and self["min_ver"].value == 0:
+            pass
+        elif self["maj_ver"].value == 0x4F54 and self["min_ver"].value == 0x544F:
+            pass
+        else:
+            return "Invalid version (%u.%u)" % (
+                self["maj_ver"].value,
+                self["min_ver"].value,
+            )
         if not (MIN_NB_TABLE <= self["nb_table"].value <= MAX_NB_TABLE):
             return "Invalid number of table (%u)" % self["nb_table"].value
         return True

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -86,6 +86,12 @@ CHARSET_MAP = {
     3: {1: "UTF-16-BE"},
 }
 
+PERMISSIONS = {
+    0: "Installable embedding",
+    2: "Restricted License embedding",
+    4: "Preview & Print embedding",
+    8: "Editable embedding",
+}
 
 FWORD = Int16
 UFWORD = UInt16
@@ -472,12 +478,25 @@ def parseHhea(self):
     yield Int16(self, "numberOfHMetrics", "Number of horizontal metrics")
 
 
+class fsType(FieldSet):
+    def createFields(self):
+        yield Enum(Bits(self, "usage_permissions", 3), PERMISSIONS)
+        yield PaddingBits(self, "reserved[]", 7)
+        yield Bit(self, "no_subsetting", "Font may not be subsetted prior to embedding")
+        yield Bit(
+            self,
+            "bitmap_embedding",
+            "Only bitmaps contained in the font may be embedded",
+        )
+        yield PaddingBits(self, "reserved[]", 6)
+
+
 def parseOS2(self):
     yield UInt16(self, "version", "Table version")
     yield Int16(self, "xAvgCharWidth")
     yield UInt16(self, "usWeightClass")
     yield UInt16(self, "usWidthClass")
-    yield UInt16(self, "fsType")
+    yield fsType(self, "fsType")
     yield Int16(self, "ySubscriptXSize")
     yield Int16(self, "ySubscriptYSize")
     yield Int16(self, "ySubscriptXOffset")

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -105,6 +105,15 @@ class Version16Dot16(FieldSet):
         return float("%u.%x" % (self["major"].value, self["minor"].value))
 
 
+class Fixed(FieldSet):
+    def createFields(self):
+        yield UInt16(self, "int_part")
+        yield UInt16(self, "float_part")
+
+    def createValue(self):
+        return self["int_part"].value + float(self["float_part"].value) / 65536
+
+
 class TableHeader(FieldSet):
     def createFields(self):
         yield Tag(self, "tag")

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -13,11 +13,22 @@ Creation date: 2007-02-08
 """
 
 from hachoir.parser import Parser
-from hachoir.field import (FieldSet, ParserError,
-                           UInt16, UInt32, Bit, Bits,
-                           PaddingBits, NullBytes,
-                           String, RawBytes, Bytes, Enum,
-                           TimestampMac32)
+from hachoir.field import (
+    FieldSet,
+    ParserError,
+    UInt16,
+    UInt32,
+    Bit,
+    Bits,
+    PaddingBits,
+    NullBytes,
+    String,
+    RawBytes,
+    Bytes,
+    Enum,
+    TimestampMac32,
+    GenericVector,
+)
 from hachoir.core.endian import BIG_ENDIAN
 from hachoir.core.text_handler import textHandler, hexadecimal, filesizeHandler
 
@@ -95,7 +106,6 @@ class TableHeader(FieldSet):
 
 
 class NameHeader(FieldSet):
-
     def createFields(self):
         yield Enum(UInt16(self, "platformID"), PLATFORM_NAME)
         yield UInt16(self, "encodingID")
@@ -147,7 +157,7 @@ def parseFontHeader(self):
     yield Bits(self, "adobe", 2, "(used by Adobe)")
 
     yield UInt16(self, "unit_per_em", "Units per em")
-    if not(16 <= self["unit_per_em"].value <= 16384):
+    if not (16 <= self["unit_per_em"].value <= 16384):
         raise ParserError("TTF: Invalid unit/em value")
     yield UInt32(self, "created_high")
     yield TimestampMac32(self, "created")
@@ -178,13 +188,11 @@ def parseNames(self):
     # Read header
     yield UInt16(self, "format")
     if self["format"].value != 0:
-        raise ParserError("TTF (names): Invalid format (%u)" %
-                          self["format"].value)
+        raise ParserError("TTF (names): Invalid format (%u)" % self["format"].value)
     yield UInt16(self, "count")
     yield UInt16(self, "offset")
     if MAX_NAME_COUNT < self["count"].value:
-        raise ParserError("Invalid number of names (%s)"
-                          % self["count"].value)
+        raise ParserError("Invalid number of names (%s)" % self["count"].value)
 
     # Read name index
     entries = []
@@ -220,7 +228,9 @@ def parseNames(self):
         # Read value
         size = entry["length"].value
         if size:
-            yield String(self, "value[]", size, entry.description, charset=entry.getCharset())
+            yield String(
+                self, "value[]", size, entry.description, charset=entry.getCharset()
+            )
 
     padding = (self.size - self.current_size) // 8
     if padding:

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -2,6 +2,8 @@
 TrueType Font parser.
 
 Documents:
+ - "The OpenType Specification"
+   https://docs.microsoft.com/en-us/typography/opentype/spec/
  - "An Introduction to TrueType Fonts: A look inside the TTF format"
    written by "NRSI: Computers & Writing Systems"
    http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&item_id=IWS-Chapter08

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -337,7 +337,6 @@ class CmapTable14(FieldSet):
 
 
 def parseCmap(self):
-    start = self.current_size / 8
     yield UInt16(self, "version")
     numTables = UInt16(self, "numTables", "Number of encoding tables")
     yield numTables
@@ -400,8 +399,9 @@ def parseDSIG(self):
         entries.append(record)
         yield record
     entries.sort(key=lambda field: field["signatureBlockOffset"].value)
+    last = None
     for entry in entries:
-        offset = er["signatureBlockOffset"].value
+        offset = entry["signatureBlockOffset"].value
         if last and last == offset:
             continue
         last = offset
@@ -611,7 +611,8 @@ def parsePost(self):
         yield indices
 
 
-parseScriptList = parseFeatureList = parseLookupList = lambda x: None
+# This is work-in-progress until I work out good ways to do random-access on offsets
+parseScriptList = parseFeatureList = parseLookupList = parseFeatureVariationsTable = lambda x: None
 
 
 def parseGSUB(self):

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -313,10 +313,9 @@ def parseCmap(self):
         last = offset
 
         # Add padding if any
-        if offset > (self.current_size / 8) - start:
-            padding = self.seekByte(offset, relative=True, null=False)
-            if padding:
-                yield padding
+        padding = self.seekByte(offset, relative=True, null=False)
+        if padding:
+            yield padding
         format = UInt16(self, "format").value
         if format == 0:
             yield CmapTable0(self, "cmap table format 0")

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -88,6 +88,11 @@ FWORD = Int16
 UFWORD = UInt16
 
 
+class Tag(String):
+    def __init__(self, parent, name, description=None):
+        String.__init__(self, parent, name, 4, description)
+
+
 class Version16Dot16(FieldSet):
     static_size = 32
 
@@ -101,7 +106,7 @@ class Version16Dot16(FieldSet):
 
 class TableHeader(FieldSet):
     def createFields(self):
-        yield String(self, "tag", 4)
+        yield Tag(self, "tag")
         yield textHandler(UInt32(self, "checksum"), hexadecimal)
         yield UInt32(self, "offset")
         yield filesizeHandler(UInt32(self, "size"))

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -591,8 +591,8 @@ def parseHhea(self):
 
 class fsType(FieldSet):
     def createFields(self):
-        yield Enum(Bits(self, "usage_permissions", 3), PERMISSIONS)
-        yield PaddingBits(self, "reserved[]", 7)
+        yield Enum(Bits(self, "usage_permissions", 4), PERMISSIONS)
+        yield PaddingBits(self, "reserved[]", 4)
         yield Bit(self, "no_subsetting", "Font may not be subsetted prior to embedding")
         yield Bit(
             self,

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -70,8 +70,18 @@ CHARSET_MAP = {
 }
 
 
-class TableHeader(FieldSet):
+class Version16Dot16(FieldSet):
+    static_size = 32
 
+    def createFields(self):
+        yield UInt16(self, "major")
+        yield UInt16(self, "minor")
+
+    def createValue(self):
+        return float("%u.%x" % (self["major"].value, self["minor"].value))
+
+
+class TableHeader(FieldSet):
     def createFields(self):
         yield String(self, "tag", 4)
         yield textHandler(UInt32(self, "checksum"), hexadecimal)

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -426,11 +426,11 @@ def parseGSUB(self):
 
 class Table(FieldSet):
     TAG_INFO = {
-        "head": ("header", "Font header", parseFontHeader),
-        "name": ("names", "Names", parseNames),
-        "maxp": ("maxp", "Maximum Profile", parseMaxp),
-        "hhea": ("hhea", "Horizontal Header", parseHhea),
         "GSUB": ("GSUB", "Glyph Substitutions", parseGSUB),
+        "head": ("header", "Font header", parseFontHeader),
+        "hhea": ("hhea", "Horizontal Header", parseHhea),
+        "maxp": ("maxp", "Maximum Profile", parseMaxp),
+        "name": ("names", "Names", parseNames),
         "OS/2": ("OS/2", "OS/2 and Windows Metrics", parseOS2),
         "post": ("post", "PostScript", parsePost),
     }

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -18,6 +18,7 @@ from hachoir.field import (
     ParserError,
     UInt16,
     UInt32,
+    Int16,
     Bit,
     Bits,
     PaddingBits,
@@ -81,6 +82,10 @@ CHARSET_MAP = {
     1: {0: "MacRoman"},
     3: {1: "UTF-16-BE"},
 }
+
+
+FWORD = Int16
+UFWORD = UInt16
 
 
 class Version16Dot16(FieldSet):

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -736,7 +736,7 @@ class Table(FieldSet):
         "hhea": ("hhea", "Horizontal Header", parseHhea),
         "maxp": ("maxp", "Maximum Profile", parseMaxp),
         "name": ("names", "Names", parseNames),
-        "OS/2": ("OS/2", "OS/2 and Windows Metrics", parseOS2),
+        "OS/2": ("OS_2", "OS/2 and Windows Metrics", parseOS2),
         "post": ("post", "PostScript", parsePost),
     }
 

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -475,7 +475,7 @@ def parseHhea(self):
     yield Int16(self, "caretOffset", "Caret offset")
     yield GenericVector(self, "reserved", 4, Int16)
     yield Int16(self, "metricDataFormat", "Metric data format")
-    yield Int16(self, "numberOfHMetrics", "Number of horizontal metrics")
+    yield UInt16(self, "numberOfHMetrics", "Number of horizontal metrics")
 
 
 class fsType(FieldSet):

--- a/hachoir/parser/misc/ttf.py
+++ b/hachoir/parser/misc/ttf.py
@@ -227,10 +227,39 @@ def parseNames(self):
         yield NullBytes(self, "padding_end", padding)
 
 
+def parseMaxp(self):
+    # Read header
+    yield Version16Dot16(self, "format", "format version")
+    yield UInt16(self, "numGlyphs", "Number of glyphs")
+    if self["format"].value >= 1:
+        yield UInt16(self, "maxPoints", "Maximum points in a non-composite glyph")
+        yield UInt16(self, "maxContours", "Maximum contours in a non-composite glyph")
+        yield UInt16(self, "maxCompositePoints", "Maximum points in a composite glyph")
+        yield UInt16(
+            self, "maxCompositeContours", "Maximum contours in a composite glyph"
+        )
+        yield UInt16(self, "maxZones", "Do instructions use the twilight zone?")
+        yield UInt16(self, "maxTwilightPoints", "Maximum points used in Z0")
+        yield UInt16(self, "maxStorage", "Number of Storage Area locations")
+        yield UInt16(self, "maxFunctionDefs", "Number of function definitions")
+        yield UInt16(self, "maxInstructionDefs", "Number of instruction definitions")
+        yield UInt16(self, "maxStackElements", "Maximum stack depth")
+        yield UInt16(
+            self, "maxSizeOfInstructions", "Maximum byte count for glyph instructions"
+        )
+        yield UInt16(
+            self,
+            "maxComponentElements",
+            "Maximum number of components at glyph top level",
+        )
+        yield UInt16(self, "maxComponentDepth", "Maximum level of recursion")
+
+
 class Table(FieldSet):
     TAG_INFO = {
         "head": ("header", "Font header", parseFontHeader),
         "name": ("names", "Names", parseNames),
+        "maxp": ("maxp", "Maximum Profile", parseMaxp),
     }
 
     def __init__(self, parent, name, table, **kw):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -836,6 +836,12 @@ class TestParsers(unittest.TestCase):
         self.checkValue(parser, "/bpp", 32)
         self.checkDisplay(parser, "/codec", "True-color RLE")
 
+    def test_ttf(self):
+        parser = self.parse("deja_vu_serif-2.7.ttf")
+        self.checkValue(parser, "/hhea/ascender", 1901)
+        self.checkValue(parser, "/maxp/maxCompositePoints", 101)
+        self.checkValue(parser, "/cmap/encodingRecords[1]/platformID", 1)
+
 
 class TestParserRandomStream(unittest.TestCase):
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -841,6 +841,7 @@ class TestParsers(unittest.TestCase):
         self.checkValue(parser, "/hhea/ascender", 1901)
         self.checkValue(parser, "/maxp/maxCompositePoints", 101)
         self.checkValue(parser, "/cmap/encodingRecords[1]/platformID", 1)
+        self.checkValue(parser, "/OS_2/achVendID", "Deja")
 
 
 class TestParserRandomStream(unittest.TestCase):


### PR DESCRIPTION
This PR:

* Adds support to the ttf parser for OpenType fonts (same content, different magic number)
* Allows the parser to unpack the `maxp`, `hhea`, `OS/2`, `post`, `cmap` and `DSIG` tables.