### PR TITLE
Set size of truncated JpegImageData to rest of stream

### DIFF
--- a/hachoir/parser/image/jpeg.py
+++ b/hachoir/parser/image/jpeg.py
@@ -387,7 +387,10 @@ class JpegImageData(FieldSet):
             end = self.stream.searchBytes(b"\xff", start, MAX_FILESIZE * 8)
             if end is None:
                 # this is a bad sign, since it means there is no terminator
-                # we ignore this; it likely means a truncated image
+                # this likely means a truncated image:
+                # set the size to the remaining length of the stream
+                # to avoid being forced to parse subfields to calculate size
+                self._size = self.stream._size - self.absolute_address
                 break
             if self.stream.readBytes(end, 2) == b'\xff\x00':
                 # padding: false alarm


### PR DESCRIPTION
Suggested fix for #67.

Set the size of an JpegImageData section with no terminator to the remainder of the stream,
on the assumption that the file is truncated in the middle of the JpegImageData and so the rest
of the file is its data. This avoids the JpegImageData being parsed to calculate it's size,
and hopefully prevents the corrupted section needing to be parsed at all for most operations.

If the JpegImageData is explicitly parsed the memory blowup and parsing errors will still happen,
but that seems like the expected outcome of parsing a large corrupt section rather than a surprise
that happens when checking for fields.