### PR TITLE
Default date info for TimeDateMSDOS32

### DIFF
--- a/hachoir/field/timestamp.py
+++ b/hachoir/field/timestamp.py
@@ -61,7 +61,7 @@ class TimeDateMSDOS32(FieldSet):
 
     def createValue(self):
         return datetime(
-            1980 + self["year"].value, self["month"].value, self["day"].value,
+            1980 + self["year"].value, self["month"].value or 1, self["day"].value or 1,
             self["hour"].value, self["minute"].value, 2 * self["second"].value)
 
     def createDisplay(self):


### PR DESCRIPTION
Datetime can't be created with 0 value for day and/or month. This should cause the value to default to 1 if the value is 0.