### PR TITLE
Allow QuickTime movies to start with "skip" atom

### DIFF
--- a/hachoir/parser/container/mp4.py
+++ b/hachoir/parser/container/mp4.py
@@ -1312,7 +1312,7 @@ class MP4File(Parser):
         if size < 8:
             return "Invalid first atom size"
         tag = self.stream.readBytes(4 * 8, 4)
-        if tag not in (b"ftyp", b"moov", b"free"):
+        if tag not in (b"ftyp", b"moov", b"free", b"skip"):
             return "Unknown MOV file type"
         return True
 


### PR DESCRIPTION
I've got some *.mov files from a (rather old) Kodak EasyShare C533 camera, which have "skip" as the container's first atom, rather than "ftyp", "moov", or "free". They therefore don't pass the check in `hachoir.parser.container.MP4File.validate()`. This initial "skip" atom seems to contain some metadata like camera model name, and is followed by an "mdat" occupying most of the file, and then finally by a "moov".

I use `hachoir` to extract movie's duration and timestamp, and it works fine if `validate()` method is tweaked to allow "skip" as the initial atom. (Apparently, all the needed info is in "moov" at the end of the file).

Admittedly, "skip" doesn't look very characteristic of a movie file, but we already have "free" on the list, so it shouldn't make things much worse.