### PR TITLE
Add hachoir-list tool

### DIFF
--- a/hachoir-list
+++ b/hachoir-list
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+from hachoir.listtool import main
+main()

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -28,7 +28,7 @@ def displayParserList(*args):
 
 
 def parseOptions():
-    parser = OptionParser(usage="%prog [options] filename")
+    parser = OptionParser(usage="%prog [options] filename [filenames...]")
 
     common = OptionGroup(parser, "List Tool", "Options of list tool")
     common.add_option("--parser", help="Use the specified parser (use its identifier)",
@@ -51,10 +51,10 @@ def parseOptions():
     parser.add_option_group(hachoir)
 
     values, arguments = parser.parse_args()
-    if len(arguments) != 1:
+    if len(arguments) < 1:
         parser.print_help()
         sys.exit(1)
-    return values, arguments[0]
+    return values, arguments
 
 
 def openParser(parser_id, filename, offset, size):
@@ -74,22 +74,24 @@ def openParser(parser_id, filename, offset, size):
 
 def main():
     # Parse options and initialize Hachoir
-    values, filename = parseOptions()
+    values, filenames = parseOptions()
     configureHachoir(values)
 
     # Open file and create parser
-    parser, err = openParser(values.parser, filename,
-                             values.offset, values.size)
-    if err:
-        print(err)
-        sys.exit(1)
+    for filename in filenames:
+        print(f"File: {filename}")
+        parser, err = openParser(values.parser, filename,
+                                 values.offset, values.size)
+        if err:
+            print(err)
+            sys.exit(1)
 
-    # Explore file
-    with parser:
-        printFieldSet(parser, values, {
-            "display_size": values.display_size,
-            "display_value": values.display_value,
-        })
+        # Explore file
+        with parser:
+            printFieldSet(parser, values, {
+                "display_size": values.display_size,
+                "display_value": values.display_value,
+            })
 
 
 if __name__ == "__main__":

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -95,8 +95,16 @@ def main():
     configureHachoir(values)
 
     # Open file and create parser
+    showing_multiple_files = len(filenames) > 1
+    i = 0
     for filename in filenames:
-        print(f"File: {filename}")
+
+        i += 1
+        if i > 1:
+            print()
+        if showing_multiple_files:
+            print(f"File: {filename}")
+
         parser, err = openParser(values.parser, filename,
                                  values.offset, values.size)
         if err:

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -10,6 +10,13 @@ from optparse import OptionGroup, OptionParser
 import sys
 
 
+def format_size(num_bits):
+    if num_bits % 8 == 0:
+        return f"{num_bits // 8}B"
+    else:
+        return f"{num_bits}b"
+
+
 def printFieldSet(field_set, args, options={}, indent=0):
     indent_string = " " * options["indent_width"] * indent
     for field in field_set:
@@ -18,7 +25,7 @@ def printFieldSet(field_set, args, options={}, indent=0):
             value_display = f": {field.display}"
         size_display = ""
         if options["display_size"]:
-            size_display = f", {field.size}b"
+            size_display = f", {format_size(field.size)}"
         description_display = ""
         if options["display_description"]:
             description_display = f" ({field.description})"

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -11,7 +11,7 @@ import sys
 
 
 def printFieldSet(field_set, args, options={}, indent=0):
-    indent_string = "  " * indent
+    indent_string = " " * options["indent_width"] * indent
     for field in field_set:
         value_display = ""
         if field.value is not None and options["display_value"]:
@@ -51,6 +51,8 @@ def parseOptions():
                       action="store_false", default=True)
     common.add_option("--hide-size", dest="display_size", help="Don't display size",
                       action="store_false", default=True)
+    common.add_option("--indent-width", dest="indent_width", help="Indentation width",
+                      type="long", action="store", default=2)
     common.add_option("--version", help="Display version and exit",
                       action="callback", callback=displayVersion)
     parser.add_option_group(common)
@@ -100,6 +102,7 @@ def main():
                 "display_description": values.display_description,
                 "display_size": values.display_size,
                 "display_value": values.display_value,
+                "indent_width": values.indent_width,
             })
 
 

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -1,0 +1,88 @@
+#
+# Tool for parsing a file and writing all fields to stdout.
+#
+
+from hachoir.core.cmd_line import getHachoirOptions, configureHachoir
+from hachoir.core.cmd_line import displayVersion
+from hachoir.stream import InputStreamError, FileInputStream
+from hachoir.parser import guessParser, HachoirParserList
+from optparse import OptionGroup, OptionParser
+import sys
+
+
+def printFieldSet(field_set, args, options={}):
+    pass
+
+
+def displayParserList(*args):
+    HachoirParserList().print_()
+    sys.exit(0)
+
+
+def parseOptions():
+    parser = OptionParser(usage="%prog [options] filename")
+
+    common = OptionGroup(parser, "List Tool", "Options of list tool")
+    common.add_option("--parser", help="Use the specified parser (use its identifier)",
+                      type="str", action="store", default=None)
+    common.add_option("--offset", help="Skip first bytes of input file",
+                      type="long", action="store", default=0)
+    common.add_option("--parser-list", help="List all parsers then exit",
+                      action="callback", callback=displayParserList)
+    common.add_option("--size", help="Maximum size of bytes of input file",
+                      type="long", action="store", default=None)
+    common.add_option("--hide-value", dest="display_value", help="Don't display value",
+                      action="store_false", default=True)
+    common.add_option("--hide-size", dest="display_size", help="Don't display size",
+                      action="store_false", default=True)
+    common.add_option("--version", help="Display version and exit",
+                      action="callback", callback=displayVersion)
+    parser.add_option_group(common)
+
+    hachoir = getHachoirOptions(parser)
+    parser.add_option_group(hachoir)
+
+    values, arguments = parser.parse_args()
+    if len(arguments) != 1:
+        parser.print_help()
+        sys.exit(1)
+    return values, arguments[0]
+
+
+def openParser(parser_id, filename, offset, size):
+    tags = []
+    if parser_id:
+        tags += [("id", parser_id), None]
+    try:
+        stream = FileInputStream(filename,
+                                 offset=offset, size=size, tags=tags)
+    except InputStreamError as err:
+        return None, "Unable to open file: %s" % err
+    parser = guessParser(stream)
+    if not parser:
+        return None, "Unable to parse file: %s" % filename
+    return parser, None
+
+
+def main():
+    # Parse options and initialize Hachoir
+    values, filename = parseOptions()
+    configureHachoir(values)
+
+    # Open file and create parser
+    parser, err = openParser(values.parser, filename,
+                             values.offset, values.size)
+    if err:
+        print(err)
+        sys.exit(1)
+
+    # Explore file
+    with parser:
+        printFieldSet(parser, values, {
+            "display_size": values.display_size,
+            "display_value": values.display_value,
+        })
+
+
+if __name__ == "__main__":
+    main()

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -10,8 +10,16 @@ from optparse import OptionGroup, OptionParser
 import sys
 
 
-def printFieldSet(field_set, args, options={}):
-    pass
+def printFieldSet(field_set, args, options={}, indent=0):
+    indent_string = "  " * indent
+    for field in field_set:
+        value_display = ""
+        if field.value is not None:
+            value_display = f" = {field.display}"
+        print(f"{indent_string}{field.name} ({field.__class__.__name__}, {field.size}){value_display}")
+
+        if field.is_field_set:
+            printFieldSet(field, args, options, indent + 1)
 
 
 def displayParserList(*args):

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -14,9 +14,12 @@ def printFieldSet(field_set, args, options={}, indent=0):
     indent_string = "  " * indent
     for field in field_set:
         value_display = ""
-        if field.value is not None:
+        if field.value is not None and options["display_value"]:
             value_display = f" = {field.display}"
-        print(f"{indent_string}{field.name} ({field.__class__.__name__}, {field.size}){value_display}")
+        size_display = ""
+        if options["display_size"]:
+            size_display = f", {field.size}"
+        print(f"{indent_string}{field.name} ({field.__class__.__name__}{size_display}){value_display}")
 
         if field.is_field_set:
             printFieldSet(field, args, options, indent + 1)

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -19,7 +19,10 @@ def printFieldSet(field_set, args, options={}, indent=0):
         size_display = ""
         if options["display_size"]:
             size_display = f", {field.size}b"
-        print(f"{indent_string}{field.name} <{field.__class__.__name__}{size_display}> ({field.description}){value_display}")
+        description_display = ""
+        if options["display_description"]:
+            description_display = f" ({field.description})"
+        print(f"{indent_string}{field.name} <{field.__class__.__name__}{size_display}>{description_display}{value_display}")
 
         if field.is_field_set:
             printFieldSet(field, args, options, indent + 1)
@@ -42,6 +45,8 @@ def parseOptions():
                       action="callback", callback=displayParserList)
     common.add_option("--size", help="Maximum size of bytes of input file",
                       type="long", action="store", default=None)
+    common.add_option("--description", dest="display_description", help="Display description",
+                      action="store_true", default=False)
     common.add_option("--hide-value", dest="display_value", help="Don't display value",
                       action="store_false", default=True)
     common.add_option("--hide-size", dest="display_size", help="Don't display size",
@@ -92,6 +97,7 @@ def main():
         # Explore file
         with parser:
             printFieldSet(parser, values, {
+                "display_description": values.display_description,
                 "display_size": values.display_size,
                 "display_value": values.display_value,
             })

--- a/hachoir/listtool.py
+++ b/hachoir/listtool.py
@@ -15,11 +15,11 @@ def printFieldSet(field_set, args, options={}, indent=0):
     for field in field_set:
         value_display = ""
         if field.value is not None and options["display_value"]:
-            value_display = f" = {field.display}"
+            value_display = f": {field.display}"
         size_display = ""
         if options["display_size"]:
-            size_display = f", {field.size}"
-        print(f"{indent_string}{field.name} ({field.__class__.__name__}{size_display}){value_display}")
+            size_display = f", {field.size}b"
+        print(f"{indent_string}{field.name} <{field.__class__.__name__}{size_display}> ({field.description}){value_display}")
 
         if field.is_field_set:
             printFieldSet(field, args, options, indent + 1)


### PR DESCRIPTION
This adds the `hachoir-list` command-line tool which just prints all parsed fields. This text output allows to e.g. use normal shell tools like `diff` and `grep` to analyze parsed files.